### PR TITLE
DEP Require classproxy ^1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "silverstripe/framework": "^4@dev",
         "silverstripe/vendor-plugin": "^1.0",
-        "tractorcow/classproxy": "^0.1.1"
+        "tractorcow/classproxy": "^1"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/10294

classproxy was recently tagged at 1.0.0 and contained a pull-request for [php 8.1 compatibility](https://github.com/tractorcow/classproxy/pull/5)

After this pull-request is merged, this module should be tagged with either 0.1.1 or 0.2.0 or 1.0.0

@tractorcow 