### PR TITLE
DEP Silverstripe CMS 5 compatibility

### DIFF
--- a/_config/proxydb.yml
+++ b/_config/proxydb.yml
@@ -5,15 +5,11 @@ After: '#databaseconnectors'
 SilverStripe\Core\Injector\Injector:
   MySQLDatabase:
     factory: TractorCow\SilverStripeProxyDB\ProxyDBFactory
-  MySQLPDODatabase:
-    factory: TractorCow\SilverStripeProxyDB\ProxyDBFactory
 ---
 Name: proxydb-postgresql
 After: '#postgresqlconnectors'
 ---
 SilverStripe\Core\Injector\Injector:
-  PostgrePDODatabase:
-    factory: TractorCow\SilverStripeProxyDB\ProxyDBFactory
   PostgreSQLDatabase:
     factory: TractorCow\SilverStripeProxyDB\ProxyDBFactory
 
@@ -22,7 +18,5 @@ Name: proxydb-sqlite
 After: '#sqlite3connectors'
 ---
 SilverStripe\Core\Injector\Injector:
-  SQLite3PDODatabase:
-    factory: TractorCow\SilverStripeProxyDB\ProxyDBFactory
   SQLite3Database:
     factory: TractorCow\SilverStripeProxyDB\ProxyDBFactory

--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
         }
     ],
     "require": {
-        "silverstripe/framework": "^4@dev",
-        "silverstripe/vendor-plugin": "^1.0",
+        "silverstripe/framework": "^5",
+        "silverstripe/vendor-plugin": "^2",
         "tractorcow/classproxy": "^1"
     },
     "autoload": {


### PR DESCRIPTION
The beta release of Silverstripe CMS 5 uses [a temporary fork](https://github.com/silverstripe/silverstripe-proxy-db).

## Parent issue
- https://github.com/silverstripeltd/product-issues/issues/658